### PR TITLE
Lista básica con tipos de tarea

### DIFF
--- a/lib/api/service/task_service.dart
+++ b/lib/api/service/task_service.dart
@@ -1,0 +1,31 @@
+import 'package:vdenis/domain/task.dart';
+import 'package:vdenis/data/task_repository.dart';
+
+class TaskService {
+  
+  final TaskRepository _taskRepository = TaskRepository(); // Instancia del repositorio
+
+  // Crear una nueva tarea
+  void createTask(Task task) {
+    print('Creando tarea: ${task.title}'); // Imprime el título de la tarea creada
+    _taskRepository.addTask(task);// Agrega la tarea al repositorio
+  }
+
+  // Leer todas las tareas
+  List<Task> getTasks() {
+    print('Obteniendo tareas'); 
+    return _taskRepository.getTasks();
+  }
+
+  // Actualizar una tarea existente
+  void updateTask(int index, Task updatedTask) {
+    print('Actualizando tarea en el índice: $index'); // Imprime el índice de la tarea actualizada
+     _taskRepository.updateTask(index, updatedTask); // Actualiza la tarea en el repositorio
+  }
+
+  // Eliminar una tarea
+  void deleteTask(int index) {
+    print('Eliminando tarea en el índice: $index'); // Imprime el índice de la tarea a eliminar
+    _taskRepository.deleteTask(index); // Elimina la tarea del repositorio
+  }
+}

--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -1,3 +1,5 @@
 const String TITLE_APPBAR = 'Lista de Tareas';
 const String EMPTY_LIST = 'No hay tareas';
 const String TASK_TYPE_LABEL = 'Tipo: ';
+const String TASK_TYPE_NORMAL = 'normal';
+const String TASK_TYPE_URGENT = 'urgente';

--- a/lib/data/task_repository.dart
+++ b/lib/data/task_repository.dart
@@ -2,7 +2,7 @@ import '../domain/task.dart';
 
 class TaskRepository {
   // Lista estática de tareas iniciales
-  final List<Task> _tasks = [
+  final List<Task> tasks = [
     Task(title: 'Tarea 1', type: 'urgente'),
     Task(title: 'Tarea 2'),
     Task(title: 'Tarea 3'),
@@ -12,6 +12,25 @@ class TaskRepository {
 
   // Método para obtener todas las tareas
   List<Task> getTasks() {
-    return _tasks;
+    return tasks;
+  }
+
+  // Método para agregar una tarea
+  void addTask(Task task) {
+    tasks.add(task);
+  }
+
+  // Método para actualizar una tarea
+  void updateTask(int index, Task updatedTask) {
+    if (index >= 0 && index < tasks.length) {
+      tasks[index] = updatedTask;
+    }
+  }
+
+  // Método para eliminar una tarea
+  void deleteTask(int index) {
+    if (index >= 0 && index < tasks.length) {
+      tasks.removeAt(index);
+    }
   }
 }

--- a/lib/domain/task.dart
+++ b/lib/domain/task.dart
@@ -3,4 +3,6 @@ class Task {
   final String type;
 
   Task({required this.title, this.type = 'normal'});
+
+  
 }


### PR DESCRIPTION
Se creó el archivo 'task_service.dart' para manejar las operaciones CRUD directamente sobre el TaskRepository.

Se modificó 'task_repository.dart' para incluir getters y setters para la lista de tareas.

Se ajustó 'tasks_screen.dart' para mostrar las tareas en un ListView.builder y manejar las operaciones CRUD.

Se realizaron ajustes en 'constants.dart' para mejorar la gestión de constantes globales.

- ListView.builder se utiliza para crear una lista de elementos de forma eficiente, generando solo los elementos visibles en la pantalla.

- El tipo de tarea (type) puede usarse para personalizar la apariencia de cada elemento de la lista. Por ejemplo, puedes cambiar el color, el ícono o el estilo del texto según el tipo de tarea.