### PR TITLE
Configuración de Clean Architecture con servicio

### DIFF
--- a/lib/api/service/task_service.dart
+++ b/lib/api/service/task_service.dart
@@ -33,4 +33,19 @@ class TaskService {
     print('Eliminando tarea en el índice: $index'); // Imprime el índice de la tarea a eliminar
     _taskRepository.deleteTask(index); 
   }
+
+  // Cargar más tareas
+  List<Task> loadMoreTasks(int nextTaskId, int count) {
+    return _taskRepository.loadMoreTasks(nextTaskId, count);
+  }
+
+  // Obtener pasos simulados para una tarea según su título
+  List<String> obtenerPasos(String titulo) {
+    print('Obteniendo pasos para la tarea: $titulo');
+    return [
+      'Paso 1: Planificar $titulo',
+      'Paso 2: Ejecutar $titulo',
+      'Paso 3: Revisar $titulo',
+    ];
+  }
 }

--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -4,3 +4,4 @@ const String TASK_TYPE_LABEL = 'Tipo: ';
 const String TASK_TYPE_NORMAL = 'normal';
 const String TASK_TYPE_URGENT = 'urgente';
 const String TASK_DESCRIPTION = 'Descripción: \n';
+const String PASOS_TITULO = 'Pasos para completar: ';

--- a/lib/data/task_repository.dart
+++ b/lib/data/task_repository.dart
@@ -1,4 +1,5 @@
 import '../domain/task.dart';
+import '../constants/constants.dart';
 
 class TaskRepository {
   // Lista estática de tareas iniciales
@@ -8,30 +9,35 @@ class TaskRepository {
       type: 'urgente',
       description: 'Descripción de la tarea 1',
       date: DateTime(2024, 4, 7),
+      fechaLimite: DateTime(2024, 4, 8).add(Duration(days: 1)),
     ),
     Task(
       title: 'Tarea 2',
       type: 'normal',
       description: 'Descripción de la tarea 2',
       date: DateTime(2024, 4, 8),
+      fechaLimite: DateTime(2024, 4, 8).add(Duration(days: 2)),
     ),
     Task(
       title: 'Tarea 3',
       type: 'urgente',
       description: 'Descripción de la tarea 3',
       date: DateTime(2024, 4, 9),
+      fechaLimite: DateTime(2024, 4, 8).add(Duration(days: 3)),
     ),
     Task(
       title: 'Tarea 4',
       type: 'normal',
       description: 'Descripción de la tarea 4',
       date: DateTime(2024, 4, 10),
+      fechaLimite: DateTime(2024, 4, 8).add(Duration(days: 4)),
     ),
     Task(
       title: 'Tarea 5',
       type: 'urgente',
       description: 'Descripción de la tarea 5',
       date: DateTime(2024, 4, 11),
+      fechaLimite: DateTime(2024, 4, 8).add(Duration(days: 5)),
     ),
     Task(
       title: 'Tarea 6',
@@ -89,5 +95,19 @@ class TaskRepository {
     } else {
       throw Exception('Índice fuera de rango');
     }
+  }
+
+  // Cargar más tareas (simulación)
+  List<Task> loadMoreTasks(int nextTaskId, int count) {
+    return List.generate(
+      count,
+      (index) => Task(
+        title: 'Tarea ${nextTaskId + index}',
+        type: (index % 2) == 0 ? TASK_TYPE_NORMAL : TASK_TYPE_URGENT,
+        description: 'Descripción de tarea ${nextTaskId + index}',
+        date: DateTime.now().add(Duration(days: index)),
+        fechaLimite: DateTime.now().add(Duration(days: index + 1)),
+      ),
+    );
   }
 }

--- a/lib/domain/task.dart
+++ b/lib/domain/task.dart
@@ -3,6 +3,8 @@ class Task {
   final String type;
   final String description;
   final DateTime date;
+  final DateTime? fechaLimite;
+  final List<String>? pasos;
 
-  Task({required this.title, this.type = 'normal', required this.description, required this.date});
+  Task({required this.title, this.type = 'normal', required this.description, required this.date, this.fechaLimite, this.pasos = const []});
 }

--- a/lib/views/tasks_screen.dart
+++ b/lib/views/tasks_screen.dart
@@ -41,13 +41,7 @@ class TasksScreenState extends State<TasksScreen> {
 
     await Future.delayed(const Duration(seconds: 1));
 
-    final newTasks = List.generate(10, (index) => Task(
-        title: 'Tarea ${_nextTaskId + index}',
-        type: (index % 2) == 0 ? TASK_TYPE_NORMAL : TASK_TYPE_URGENT, // Intercalado
-        description: 'Descripción de tarea ${_nextTaskId + index}',
-        date: DateTime.now().add(Duration(days: index)),
-      ),
-    );
+    final newTasks = _taskService.loadMoreTasks(_nextTaskId, 10); // Carga más tareas
 
     setState(() {
       tasks.addAll(newTasks);


### PR DESCRIPTION
Se ha modificado el método '_loadMoreTasks' del archivo 'task_service.dart' para que la lógica de paginación se realice en el task_repository y llamando desde el servicio para mantener una Clean Architecture.

Se añadieron dos nuevos campos a la clase Task:
- 'pasos': que se inicializa como una lista vacía.
- 'fechaLimite': que se inicializa como una fecha futura.

En Clean Architecture, el servicio juega un papel crucial como intermediario entre la capa de dominio (donde residen las reglas de negocio) y la capa de datos.

El servicio tiene una instancia del 'task_repository' para acceder a las operaciones CRUD.