### PR TITLE
se agrega el jwt a las peticiones del service

### DIFF
--- a/lib/api/service/auth_service.dart
+++ b/lib/api/service/auth_service.dart
@@ -8,7 +8,7 @@ class AuthService extends BaseService {
   
   Future<LoginResponse> login(LoginRequest request) async {
     try {
-      final data = await post(
+      final data = await postUnauthorized(
         '/login',
         data: request.toJson(),   
       );


### PR DESCRIPTION
- Se cambió la bandera de los métodos CRUD del service para que reciban el JWT dentro del header.
- Se creó un nuevo método para las solicitudes de tipo POST que no requieren el JWT (Login).